### PR TITLE
refactor: [#13] extract logic into libraries and include base contracts to ensure order for upgrades

### DIFF
--- a/contracts/consumables/Paypr.sol
+++ b/contracts/consumables/Paypr.sol
@@ -14,8 +14,19 @@ import '../core/consumable/ConsumableExchange.sol';
 import '../core/consumable/ConvertibleConsumable.sol';
 import '../core/access/DelegatingRoles.sol';
 
-contract Paypr is ConvertibleConsumable, ConsumableExchange, DelegatingRoles {
+contract Paypr is
+  Initializable,
+  ContextUpgradeSafe,
+  ERC165UpgradeSafe,
+  BaseContract,
+  Consumable,
+  ConvertibleConsumable,
+  ConsumableExchange,
+  Disableable,
+  DelegatingRoles
+{
   using SafeMath for uint256;
+  using TransferLogic for address;
 
   function initializePaypr(
     IConsumableExchange baseToken,
@@ -77,8 +88,8 @@ contract Paypr is ConvertibleConsumable, ConsumableExchange, DelegatingRoles {
     address sender,
     address recipient,
     uint256 amount
-  ) internal override(ConsumableExchange, ConvertibleConsumable) onlyEnabled {
-    ConsumableExchange._transfer(sender, recipient, amount);
+  ) internal override(Consumable, ConsumableExchange, ConvertibleConsumable) onlyEnabled {
+    ConvertibleConsumable._transfer(sender, recipient, amount);
   }
 
   function transferToken(
@@ -86,7 +97,7 @@ contract Paypr is ConvertibleConsumable, ConsumableExchange, DelegatingRoles {
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -94,7 +105,7 @@ contract Paypr is ConvertibleConsumable, ConsumableExchange, DelegatingRoles {
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/consumables/TestStableCoin.sol
+++ b/contracts/consumables/TestStableCoin.sol
@@ -24,7 +24,7 @@ pragma solidity ^0.6.0;
 import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol';
 import '../core/access/Roles.sol';
 
-contract TestStableCoin is ERC20UpgradeSafe, Roles {
+contract TestStableCoin is Initializable, ContextUpgradeSafe, ERC20UpgradeSafe, AccessControlUpgradeSafe, Roles {
   function initialize() external initializer {
     __ERC20_init('MyStableCoin', 'MSC');
 

--- a/contracts/core/BaseContract.sol
+++ b/contracts/core/BaseContract.sol
@@ -26,13 +26,7 @@ import '@openzeppelin/contracts-ethereum-package/contracts/introspection/ERC165.
 import './IBaseContract.sol';
 import './BaseContractInterfaceSupport.sol';
 
-contract BaseContract is IBaseContract, ERC165UpgradeSafe {
-  struct ContractInfo {
-    string name;
-    string description;
-    string uri;
-  }
-
+contract BaseContract is Initializable, IBaseContract, ERC165UpgradeSafe {
   ContractInfo private _info;
 
   function _initializeBaseContract(ContractInfo memory info) internal initializer {

--- a/contracts/core/Disableable.sol
+++ b/contracts/core/Disableable.sol
@@ -21,32 +21,18 @@
 
 pragma solidity ^0.6.0;
 
-abstract contract Disableable {
+import './IDisableable.sol';
+
+abstract contract Disableable is IDisableable {
   bool private _disabled;
 
-  /**
-   * @dev Returns whether or not the contract is disabled
-   */
-  function disabled() external view returns (bool) {
+  function disabled() external override view returns (bool) {
     return _disabled;
   }
 
-  /**
-   * @dev Returns whether or not the contract is enabled
-   */
-  function enabled() external view returns (bool) {
+  function enabled() external override view returns (bool) {
     return !_disabled;
   }
-
-  modifier onlyEnabled() {
-    require(!_disabled, 'Contract is disabled');
-    _;
-  }
-
-  /**
-   * @dev Disables the contract
-   */
-  function disable() external virtual;
 
   /**
    * @dev Disables the contract
@@ -63,11 +49,6 @@ abstract contract Disableable {
   /**
    * @dev Enables the contract
    */
-  function enable() external virtual;
-
-  /**
-   * @dev Enables the contract
-   */
   function _enable() internal {
     if (!_disabled) {
       return;
@@ -76,16 +57,6 @@ abstract contract Disableable {
     _disabled = false;
     emit Enabled();
   }
-
-  /**
-   * Emitted when the contract is disabled
-   */
-  event Disabled();
-
-  /**
-   * Emitted when the contract is enabled
-   */
-  event Enabled();
 
   uint256[50] private ______gap;
 }

--- a/contracts/core/IBaseContract.sol
+++ b/contracts/core/IBaseContract.sol
@@ -24,6 +24,12 @@ pragma solidity ^0.6.0;
 import '@openzeppelin/contracts-ethereum-package/contracts/introspection/IERC165.sol';
 
 interface IBaseContract is IERC165 {
+  struct ContractInfo {
+    string name;
+    string description;
+    string uri;
+  }
+
   function contractName() external view returns (string memory);
 
   function contractDescription() external view returns (string memory);

--- a/contracts/core/IDisableable.sol
+++ b/contracts/core/IDisableable.sol
@@ -21,27 +21,39 @@
 
 pragma solidity ^0.6.0;
 
-import '@openzeppelin/contracts-ethereum-package/contracts/introspection/IERC165.sol';
-import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/IERC20.sol';
-import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/IERC721.sol';
-import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/IERC721Receiver.sol';
-
-interface ITransferring is IERC165, IERC721Receiver {
+interface IDisableable {
   /**
-   * @dev Transfer the given amount of an ERC20 token to the given recipient address.
+   * Emitted when the contract is disabled
    */
-  function transferToken(
-    IERC20 token,
-    uint256 amount,
-    address recipient
-  ) external;
+  event Disabled();
 
   /**
-   * @dev Transfer the given item of an ERC721 token to the given recipient address.
+   * Emitted when the contract is enabled
    */
-  function transferItem(
-    IERC721 artifact,
-    uint256 itemId,
-    address recipient
-  ) external;
+  event Enabled();
+
+  /**
+   * @dev Returns whether or not the contract is disabled
+   */
+  function disabled() external view returns (bool);
+
+  /**
+   * @dev Returns whether or not the contract is enabled
+   */
+  function enabled() external view returns (bool);
+
+  modifier onlyEnabled() virtual {
+    require(!this.disabled(), 'Contract is disabled');
+    _;
+  }
+
+  /**
+   * @dev Disables the contract
+   */
+  function disable() external;
+
+  /**
+   * @dev Enables the contract
+   */
+  function enable() external;
 }

--- a/contracts/core/access/ConfigurableRoles.sol
+++ b/contracts/core/access/ConfigurableRoles.sol
@@ -27,7 +27,7 @@ import '@openzeppelin/contracts-ethereum-package/contracts/introspection/ERC165.
 import './Roles.sol';
 import './RoleDelegateInterfaceSupport.sol';
 
-contract ConfigurableRoles is Roles, ERC165UpgradeSafe {
+contract ConfigurableRoles is Initializable, ContextUpgradeSafe, ERC165UpgradeSafe, Roles {
   function initializeRoles(IRoleDelegate roleDelegate) public initializer {
     __ERC165_init();
     _registerInterface(RoleDelegateInterfaceSupport.ROLE_DELEGATE_INTERFACE_ID);

--- a/contracts/core/access/DelegatingRoles.sol
+++ b/contracts/core/access/DelegatingRoles.sol
@@ -27,7 +27,7 @@ import './IRoleDelegate.sol';
 import './RoleDelegateInterfaceSupport.sol';
 import './RoleSupport.sol';
 
-contract DelegatingRoles is ContextUpgradeSafe {
+contract DelegatingRoles is Initializable, ContextUpgradeSafe {
   using EnumerableSet for EnumerableSet.AddressSet;
   using RoleDelegateInterfaceSupport for IRoleDelegate;
 

--- a/contracts/core/access/Roles.sol
+++ b/contracts/core/access/Roles.sol
@@ -26,7 +26,7 @@ import './DelegatingRoles.sol';
 import './IRoleDelegate.sol';
 import './RoleSupport.sol';
 
-contract Roles is IRoleDelegate, DelegatingRoles, AccessControlUpgradeSafe {
+contract Roles is IRoleDelegate, Initializable, ContextUpgradeSafe, AccessControlUpgradeSafe, DelegatingRoles {
   function _initializeRoles(IRoleDelegate roleDelegate) public initializer {
     if (address(roleDelegate) != address(0)) {
       _addRoleDelegate(roleDelegate);

--- a/contracts/core/activity/Activity.sol
+++ b/contracts/core/activity/Activity.sol
@@ -31,22 +31,24 @@ import '../consumable/ConsumableConsumerInterfaceSupport.sol';
 import '../consumable/ConsumableProvider.sol';
 import '../consumable/ConsumableProviderInterfaceSupport.sol';
 import '../BaseContract.sol';
-import '../item/ItemUser.sol';
-import '../Disableable.sol';
-import '../transfer/BaseTransferring.sol';
+import '../IDisableable.sol';
 import '../transfer/TransferringInterfaceSupport.sol';
+import '../transfer/ITransferring.sol';
+import '../transfer/TransferLogic.sol';
 
 abstract contract Activity is
+  IDisableable,
+  Initializable,
+  ITransferring,
   IActivity,
   ContextUpgradeSafe,
+  ERC165UpgradeSafe,
   BaseContract,
-  BaseTransferring,
-  Disableable,
   ConsumableConsumer,
-  ConsumableProvider,
-  ItemUser
+  ConsumableProvider
 {
   using Counters for Counters.Counter;
+  using TransferLogic for address;
 
   mapping(address => Counters.Counter) private _executed;
   Counters.Counter private _totalExecuted;
@@ -99,6 +101,15 @@ abstract contract Activity is
 
   function _checkRequirements(address player) internal virtual view {
     // does nothing by default
+  }
+
+  function onERC721Received(
+    address operator,
+    address from,
+    uint256 tokenId,
+    bytes calldata data
+  ) external virtual override returns (bytes4) {
+    return TransferLogic.onERC721Received(operator, from, tokenId, data);
   }
 
   uint256[50] private ______gap;

--- a/contracts/core/activity/ConfigurableActivity.sol
+++ b/contracts/core/activity/ConfigurableActivity.sol
@@ -24,8 +24,11 @@ pragma experimental ABIEncoderV2;
 
 import './Activity.sol';
 import '../access/DelegatingRoles.sol';
+import '../Disableable.sol';
 
-contract ConfigurableActivity is Activity, DelegatingRoles {
+contract ConfigurableActivity is Initializable, ContextUpgradeSafe, Activity, Disableable, DelegatingRoles {
+  using TransferLogic for address;
+
   function initializeActivity(
     ContractInfo memory info,
     IConsumable.ConsumableAmount[] memory amountsToConsume,
@@ -42,7 +45,7 @@ contract ConfigurableActivity is Activity, DelegatingRoles {
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -50,7 +53,7 @@ contract ConfigurableActivity is Activity, DelegatingRoles {
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/core/activity/ConfigurableExchangingActivity.sol
+++ b/contracts/core/activity/ConfigurableExchangingActivity.sol
@@ -24,8 +24,17 @@ pragma experimental ABIEncoderV2;
 
 import './ExchangingActivity.sol';
 import '../access/DelegatingRoles.sol';
+import '../Disableable.sol';
 
-contract ConfigurableExchangingActivity is ExchangingActivity, DelegatingRoles {
+contract ConfigurableExchangingActivity is
+  Initializable,
+  ContextUpgradeSafe,
+  ExchangingActivity,
+  Disableable,
+  DelegatingRoles
+{
+  using TransferLogic for address;
+
   function initializeExchangingActivity(
     ContractInfo memory info,
     IConsumable.ConsumableAmount[] memory amountsToConsume,
@@ -43,7 +52,7 @@ contract ConfigurableExchangingActivity is ExchangingActivity, DelegatingRoles {
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -51,7 +60,7 @@ contract ConfigurableExchangingActivity is ExchangingActivity, DelegatingRoles {
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/core/activity/ConfigurableSkillConstrainedExchangingActivity.sol
+++ b/contracts/core/activity/ConfigurableSkillConstrainedExchangingActivity.sol
@@ -25,8 +25,19 @@ pragma experimental ABIEncoderV2;
 import './ExchangingActivity.sol';
 import '../skill/SkillConstrained.sol';
 import '../access/DelegatingRoles.sol';
+import '../Disableable.sol';
 
-contract ConfigurableSkillConstrainedExchangingActivity is SkillConstrained, ExchangingActivity, DelegatingRoles {
+contract ConfigurableSkillConstrainedExchangingActivity is
+  Initializable,
+  ContextUpgradeSafe,
+  ERC165UpgradeSafe,
+  ExchangingActivity,
+  SkillConstrained,
+  Disableable,
+  DelegatingRoles
+{
+  using TransferLogic for address;
+
   function initializeSkillConstrainedExchangingActivity(
     ContractInfo memory info,
     SkillLevel[] memory requiredSkillLevels,
@@ -47,7 +58,7 @@ contract ConfigurableSkillConstrainedExchangingActivity is SkillConstrained, Exc
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -55,7 +66,7 @@ contract ConfigurableSkillConstrainedExchangingActivity is SkillConstrained, Exc
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function _checkRequirements(address player) internal override view {

--- a/contracts/core/activity/ExchangingActivity.sol
+++ b/contracts/core/activity/ExchangingActivity.sol
@@ -27,7 +27,6 @@ import './Activity.sol';
 import '../consumable/ConsumableExchangeInterfaceSupport.sol';
 import '../consumable/IConsumableExchange.sol';
 import '../consumable/IConvertibleConsumable.sol';
-import '../consumable/ConsumableExchange.sol';
 import '../consumable/ConsumableConversionMath.sol';
 
 abstract contract ExchangingActivity is Activity {

--- a/contracts/core/consumable/ConfigurableConsumable.sol
+++ b/contracts/core/consumable/ConfigurableConsumable.sol
@@ -25,7 +25,9 @@ pragma experimental ABIEncoderV2;
 import './Consumable.sol';
 import '../access/DelegatingRoles.sol';
 
-contract ConfigurableConsumable is Consumable, DelegatingRoles {
+contract ConfigurableConsumable is Initializable, ContextUpgradeSafe, Consumable, Disableable, DelegatingRoles {
+  using TransferLogic for address;
+
   function initializeConsumable(
     ContractInfo memory info,
     string memory symbol,
@@ -61,7 +63,7 @@ contract ConfigurableConsumable is Consumable, DelegatingRoles {
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -69,7 +71,7 @@ contract ConfigurableConsumable is Consumable, DelegatingRoles {
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/core/consumable/ConfigurableConvertibleConsumable.sol
+++ b/contracts/core/consumable/ConfigurableConvertibleConsumable.sol
@@ -25,7 +25,15 @@ pragma experimental ABIEncoderV2;
 import './ConvertibleConsumable.sol';
 import '../access/DelegatingRoles.sol';
 
-contract ConfigurableConvertibleConsumable is ConvertibleConsumable, DelegatingRoles {
+contract ConfigurableConvertibleConsumable is
+  Initializable,
+  ContextUpgradeSafe,
+  ConvertibleConsumable,
+  Disableable,
+  DelegatingRoles
+{
+  using TransferLogic for address;
+
   function initializeConvertibleConsumable(
     ContractInfo memory info,
     string memory symbol,
@@ -79,7 +87,7 @@ contract ConfigurableConvertibleConsumable is ConvertibleConsumable, DelegatingR
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -87,7 +95,7 @@ contract ConfigurableConvertibleConsumable is ConvertibleConsumable, DelegatingR
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/core/consumable/ConfigurableLimitedConsumable.sol
+++ b/contracts/core/consumable/ConfigurableLimitedConsumable.sol
@@ -25,7 +25,15 @@ pragma experimental ABIEncoderV2;
 import './LimitedConsumable.sol';
 import '../access/DelegatingRoles.sol';
 
-contract ConfigurableLimitedConsumable is LimitedConsumable, DelegatingRoles {
+contract ConfigurableLimitedConsumable is
+  Initializable,
+  ContextUpgradeSafe,
+  LimitedConsumable,
+  Disableable,
+  DelegatingRoles
+{
+  using TransferLogic for address;
+
   function initializeLimitedConsumable(
     ContractInfo memory info,
     string memory symbol,
@@ -79,7 +87,7 @@ contract ConfigurableLimitedConsumable is LimitedConsumable, DelegatingRoles {
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -87,7 +95,7 @@ contract ConfigurableLimitedConsumable is LimitedConsumable, DelegatingRoles {
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/core/consumable/Consumable.sol
+++ b/contracts/core/consumable/Consumable.sol
@@ -22,15 +22,28 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
+import '@openzeppelin/contracts-ethereum-package/contracts/introspection/ERC165.sol';
 import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol';
-import '../BaseContract.sol';
-import '../Disableable.sol';
 import './ConsumableInterfaceSupport.sol';
 import './IConsumable.sol';
-import '../transfer/BaseTransferring.sol';
+import '../BaseContract.sol';
+import '../Disableable.sol';
 import '../transfer/TransferringInterfaceSupport.sol';
+import '../transfer/ITransferring.sol';
+import '../transfer/TransferLogic.sol';
 
-abstract contract Consumable is IConsumable, BaseContract, BaseTransferring, ERC20UpgradeSafe, Disableable {
+abstract contract Consumable is
+  IDisableable,
+  Initializable,
+  ITransferring,
+  ContextUpgradeSafe,
+  IConsumable,
+  ERC165UpgradeSafe,
+  BaseContract,
+  ERC20UpgradeSafe
+{
+  using TransferLogic for address;
+
   function _initializeConsumable(ContractInfo memory info, string memory symbol) internal initializer {
     _initializeBaseContract(info);
     _registerInterface(ConsumableInterfaceSupport.CONSUMABLE_INTERFACE_ID);
@@ -53,6 +66,15 @@ abstract contract Consumable is IConsumable, BaseContract, BaseTransferring, ERC
     uint256 amount
   ) internal virtual override onlyEnabled {
     super._transfer(sender, recipient, amount);
+  }
+
+  function onERC721Received(
+    address operator,
+    address from,
+    uint256 tokenId,
+    bytes calldata data
+  ) external virtual override returns (bytes4) {
+    return TransferLogic.onERC721Received(operator, from, tokenId, data);
   }
 
   uint256[50] private ______gap;

--- a/contracts/core/consumable/TestConsumableExchange.sol
+++ b/contracts/core/consumable/TestConsumableExchange.sol
@@ -25,7 +25,9 @@ pragma experimental ABIEncoderV2;
 import './ConsumableExchange.sol';
 import '../access/Roles.sol';
 
-contract TestConsumableExchange is ConsumableExchange, Roles {
+contract TestConsumableExchange is ConsumableExchange, Disableable, Roles {
+  using TransferLogic for address;
+
   function initializeConsumableExchange(ContractInfo memory info, string memory symbol) public initializer {
     _initializeConsumableExchange(info, symbol);
 
@@ -40,7 +42,7 @@ contract TestConsumableExchange is ConsumableExchange, Roles {
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -48,7 +50,7 @@ contract TestConsumableExchange is ConsumableExchange, Roles {
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   /**

--- a/contracts/core/item/Artifact.sol
+++ b/contracts/core/item/Artifact.sol
@@ -27,18 +27,24 @@ import './ArtifactInterfaceSupport.sol';
 import './IArtifact.sol';
 import '../consumable/ConsumableProvider.sol';
 import '../consumable/ConsumableProviderInterfaceSupport.sol';
-import '../Disableable.sol';
-import '../transfer/BaseTransferring.sol';
+import '../IDisableable.sol';
 import '../transfer/TransferringInterfaceSupport.sol';
+import '../transfer/TransferLogic.sol';
+import '../transfer/ITransferring.sol';
 
 abstract contract Artifact is
+  IDisableable,
+  Initializable,
+  ContextUpgradeSafe,
+  ITransferring,
+  ERC165UpgradeSafe,
   IArtifact,
   BaseContract,
-  BaseTransferring,
   ConsumableProvider,
-  ERC721UpgradeSafe,
-  Disableable
+  ERC721UpgradeSafe
 {
+  using TransferLogic for address;
+
   uint256 private _initialUses;
 
   mapping(uint256 => uint256) private _usesLeft;
@@ -100,6 +106,15 @@ abstract contract Artifact is
 
   function _checkEnoughConsumable() internal {
     require(_canProvideMultiple(_totalUsesLeft), 'Artifact: not enough consumable for items');
+  }
+
+  function onERC721Received(
+    address operator,
+    address from,
+    uint256 tokenId,
+    bytes calldata data
+  ) external virtual override returns (bytes4) {
+    return TransferLogic.onERC721Received(operator, from, tokenId, data);
   }
 
   uint256[50] private ______gap;

--- a/contracts/core/item/ConfigurableArtifact.sol
+++ b/contracts/core/item/ConfigurableArtifact.sol
@@ -25,8 +25,11 @@ pragma experimental ABIEncoderV2;
 import '@openzeppelin/contracts-ethereum-package/contracts/utils/Counters.sol';
 import './Artifact.sol';
 import '../access/DelegatingRoles.sol';
+import '../Disableable.sol';
 
-contract ConfigurableArtifact is Artifact, DelegatingRoles {
+contract ConfigurableArtifact is Initializable, ContextUpgradeSafe, Artifact, Disableable, DelegatingRoles {
+  using TransferLogic for address;
+
   using Counters for Counters.Counter;
 
   Counters.Counter private _lastItemId;
@@ -58,7 +61,7 @@ contract ConfigurableArtifact is Artifact, DelegatingRoles {
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
     _checkEnoughConsumable();
   }
 
@@ -67,7 +70,7 @@ contract ConfigurableArtifact is Artifact, DelegatingRoles {
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/core/item/ItemUserLogic.sol
+++ b/contracts/core/item/ItemUserLogic.sol
@@ -20,22 +20,19 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 pragma solidity ^0.6.0;
-pragma experimental ABIEncoderV2;
 
 import './IArtifact.sol';
 import './ArtifactInterfaceSupport.sol';
 
-abstract contract ItemUser {
+library ItemUserLogic {
   using ArtifactInterfaceSupport for IArtifact;
 
-  function _useItems(IArtifact.Item[] memory useItems, address action) internal {
-    for (uint256 itemIndex = 0; itemIndex < useItems.length; itemIndex++) {
-      IArtifact.Item memory item = useItems[itemIndex];
+  function useItems(address action, IArtifact.Item[] memory itemsToUse) internal {
+    for (uint256 itemIndex = 0; itemIndex < itemsToUse.length; itemIndex++) {
+      IArtifact.Item memory item = itemsToUse[itemIndex];
       IArtifact artifact = item.artifact;
       require(artifact.supportsArtifactInterface(), 'ItemUser: item address must support IArtifact');
       artifact.useItem(item.itemId, action);
     }
   }
-
-  uint256[50] private ______gap;
 }

--- a/contracts/core/skill/ConfigurableConstrainedSkill.sol
+++ b/contracts/core/skill/ConfigurableConstrainedSkill.sol
@@ -24,8 +24,17 @@ pragma experimental ABIEncoderV2;
 
 import './ConstrainedSkill.sol';
 import '../access/DelegatingRoles.sol';
+import '../Disableable.sol';
 
-contract ConfigurableConstrainedSkill is ConstrainedSkill, DelegatingRoles {
+contract ConfigurableConstrainedSkill is
+  Initializable,
+  ContextUpgradeSafe,
+  ConstrainedSkill,
+  Disableable,
+  DelegatingRoles
+{
+  using TransferLogic for address;
+
   function initializeConstrainedSkill(
     ContractInfo memory info,
     IConsumable.ConsumableAmount[] memory amountsToConsume,
@@ -43,7 +52,7 @@ contract ConfigurableConstrainedSkill is ConstrainedSkill, DelegatingRoles {
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -51,7 +60,7 @@ contract ConfigurableConstrainedSkill is ConstrainedSkill, DelegatingRoles {
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/core/skill/ConfigurableSkill.sol
+++ b/contracts/core/skill/ConfigurableSkill.sol
@@ -24,8 +24,11 @@ pragma experimental ABIEncoderV2;
 
 import './Skill.sol';
 import '../access/DelegatingRoles.sol';
+import '../Disableable.sol';
 
-contract ConfigurableSkill is Skill, DelegatingRoles {
+contract ConfigurableSkill is Initializable, ContextUpgradeSafe, Skill, Disableable, DelegatingRoles {
+  using TransferLogic for address;
+
   function initializeSkill(ContractInfo memory info, IRoleDelegate roleDelegate) public initializer {
     _initializeSkill(info);
 
@@ -37,7 +40,7 @@ contract ConfigurableSkill is Skill, DelegatingRoles {
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -45,7 +48,7 @@ contract ConfigurableSkill is Skill, DelegatingRoles {
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/core/skill/ConstrainedSkill.sol
+++ b/contracts/core/skill/ConstrainedSkill.sol
@@ -27,7 +27,14 @@ import './Skill.sol';
 import '../consumable/ConsumableConsumer.sol';
 import '../consumable/ConsumableConsumerInterfaceSupport.sol';
 
-abstract contract ConstrainedSkill is Skill, SkillConstrained, ConsumableConsumer {
+abstract contract ConstrainedSkill is
+  Initializable,
+  ContextUpgradeSafe,
+  ERC165UpgradeSafe,
+  Skill,
+  SkillConstrained,
+  ConsumableConsumer
+{
   using ConsumableInterfaceSupport for IConsumable;
 
   function _initializeConstrainedSkill(ContractInfo memory info, IConsumable.ConsumableAmount[] memory amountsToConsume)

--- a/contracts/core/skill/Skill.sol
+++ b/contracts/core/skill/Skill.sol
@@ -26,11 +26,22 @@ import '@openzeppelin/contracts-ethereum-package/contracts/GSN/Context.sol';
 import '../BaseContract.sol';
 import './ISkill.sol';
 import './SkillInterfaceSupport.sol';
-import '../Disableable.sol';
-import '../transfer/BaseTransferring.sol';
+import '../IDisableable.sol';
 import '../transfer/TransferringInterfaceSupport.sol';
+import '../transfer/ITransferring.sol';
+import '../transfer/TransferLogic.sol';
 
-abstract contract Skill is ISkill, ContextUpgradeSafe, BaseContract, BaseTransferring, Disableable {
+abstract contract Skill is
+  IDisableable,
+  Initializable,
+  ITransferring,
+  ISkill,
+  ContextUpgradeSafe,
+  ERC165UpgradeSafe,
+  BaseContract
+{
+  using TransferLogic for address;
+
   mapping(address => uint256) private _levels;
 
   function _initializeSkill(ContractInfo memory info) internal initializer {
@@ -84,6 +95,15 @@ abstract contract Skill is ISkill, ContextUpgradeSafe, BaseContract, BaseTransfe
 
   function _checkPreviousLevel(address player, uint256 level) internal view {
     require(level == _levels[player] + 1, 'Skill: acquire invalid level');
+  }
+
+  function onERC721Received(
+    address operator,
+    address from,
+    uint256 tokenId,
+    bytes calldata data
+  ) external virtual override returns (bytes4) {
+    return TransferLogic.onERC721Received(operator, from, tokenId, data);
   }
 
   uint256[50] private ______gap;

--- a/contracts/core/skill/SkillConstrained.sol
+++ b/contracts/core/skill/SkillConstrained.sol
@@ -27,7 +27,7 @@ import './ISkillConstrained.sol';
 import './SkillConstrainedInterfaceSupport.sol';
 import './SkillInterfaceSupport.sol';
 
-contract SkillConstrained is ISkillConstrained, ERC165UpgradeSafe {
+contract SkillConstrained is Initializable, ISkillConstrained, ERC165UpgradeSafe {
   using SkillInterfaceSupport for ISkill;
 
   struct SkillLevel {

--- a/contracts/core/transfer/TestTransfer.sol
+++ b/contracts/core/transfer/TestTransfer.sol
@@ -22,12 +22,15 @@
 pragma solidity ^0.6.0;
 
 import '@openzeppelin/contracts-ethereum-package/contracts/introspection/ERC165.sol';
-import './BaseTransferring.sol';
 import './TransferringInterfaceSupport.sol';
 import '../access/Roles.sol';
 import '../Disableable.sol';
+import './ITransferring.sol';
+import './TransferLogic.sol';
 
-contract TestTransfer is BaseTransferring, ERC165UpgradeSafe, Disableable, Roles {
+contract TestTransfer is ITransferring, ERC165UpgradeSafe, Disableable, Roles {
+  using TransferLogic for address;
+
   function initializeTestTransfer() external initializer {
     _registerInterface(TransferringInterfaceSupport.TRANSFERRING_INTERFACE_ID);
     _addSuperAdmin(_msgSender());
@@ -40,7 +43,7 @@ contract TestTransfer is BaseTransferring, ERC165UpgradeSafe, Disableable, Roles
     uint256 amount,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferToken(token, amount, recipient);
+    address(this).transferToken(token, amount, recipient);
   }
 
   function transferItem(
@@ -48,7 +51,16 @@ contract TestTransfer is BaseTransferring, ERC165UpgradeSafe, Disableable, Roles
     uint256 itemId,
     address recipient
   ) external override onlyTransferAgent onlyEnabled {
-    _transferItem(artifact, itemId, recipient);
+    address(this).transferItem(artifact, itemId, recipient);
+  }
+
+  function onERC721Received(
+    address operator,
+    address from,
+    uint256 tokenId,
+    bytes calldata data
+  ) external virtual override returns (bytes4) {
+    return TransferLogic.onERC721Received(operator, from, tokenId, data);
   }
 
   function disable() external override onlyAdmin {

--- a/contracts/core/transfer/TransferLogic.sol
+++ b/contracts/core/transfer/TransferLogic.sol
@@ -24,14 +24,14 @@ pragma solidity ^0.6.0;
 import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol';
 import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/IERC721.sol';
 import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/IERC721Receiver.sol';
-import './ITransferring.sol';
 import '../consumable/IConvertibleConsumable.sol';
 import '../consumable/ConvertibleConsumableInterfaceSupport.sol';
 
-abstract contract BaseTransferring is ITransferring, IERC721Receiver {
+library TransferLogic {
   using ConvertibleConsumableInterfaceSupport for IConvertibleConsumable;
 
-  function _transferToken(
+  function transferToken(
+    address, /*account*/
     IERC20 token,
     uint256 amount,
     address recipient
@@ -39,12 +39,13 @@ abstract contract BaseTransferring is ITransferring, IERC721Receiver {
     token.transfer(recipient, amount);
   }
 
-  function _transferTokenWithExchange(
+  function transferTokenWithExchange(
+    address account,
     IERC20 token,
     uint256 amount,
     address recipient
   ) internal {
-    uint256 myBalance = token.balanceOf(address(this));
+    uint256 myBalance = token.balanceOf(account);
     if (myBalance < amount && IConvertibleConsumable(address(token)).supportsConvertibleConsumableInterface()) {
       // increase allowance as needed, but only if it's a convertible consumable
       IConvertibleConsumable convertibleConsumable = IConvertibleConsumable(address(token));
@@ -59,20 +60,21 @@ abstract contract BaseTransferring is ITransferring, IERC721Receiver {
     token.transfer(recipient, amount);
   }
 
-  function _transferItem(
+  function transferItem(
+    address account,
     IERC721 artifact,
     uint256 itemId,
     address recipient
   ) internal {
-    artifact.safeTransferFrom(address(this), recipient, itemId);
+    artifact.safeTransferFrom(account, recipient, itemId);
   }
 
   function onERC721Received(
     address, /*operator*/
     address, /*from*/
     uint256, /*tokenId*/
-    bytes calldata /*data*/
-  ) external virtual override returns (bytes4) {
-    return this.onERC721Received.selector;
+    bytes memory /*data*/
+  ) internal pure returns (bytes4) {
+    return IERC721Receiver.onERC721Received.selector;
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: storage locations could have changed for any of these contracts, which means old contracts cannot be safely upgraded.