### PR TITLE
Rename AccessControl admins to members

### DIFF
--- a/contracts/facets/access/AccessControlInit.sol
+++ b/contracts/facets/access/AccessControlInit.sol
@@ -25,7 +25,7 @@ import './AccessControlImpl.sol';
 import '../context/ContextSupport.sol';
 
 contract AccessControlInit {
-  function initializeAdmins(bytes32[] calldata roles) external {
+  function addRoles(bytes32[] calldata roles) external {
     address account = ContextSupport.msgSender();
 
     for (uint256 index = 0; index < roles.length; index++) {
@@ -34,15 +34,15 @@ contract AccessControlInit {
     }
   }
 
-  struct RoleAdmins {
+  struct RoleMembers {
     bytes32 role;
-    address[] admins;
+    address[] members;
   }
 
-  function addAdmins(RoleAdmins[] calldata roleAdmins) external {
-    for (uint256 index = 0; index < roleAdmins.length; index++) {
-      bytes32 role = roleAdmins[index].role;
-      address[] calldata admins = roleAdmins[index].admins;
+  function addMembers(RoleMembers[] calldata roleMembers) external {
+    for (uint256 index = 0; index < roleMembers.length; index++) {
+      bytes32 role = roleMembers[index].role;
+      address[] calldata admins = roleMembers[index].members;
 
       for (uint256 adminIndex = 0; adminIndex < admins.length; adminIndex++) {
         AccessControlImpl.grantRole(role, admins[adminIndex]);

--- a/spec/contracts/core/diamond/Diamond.spec.ts
+++ b/spec/contracts/core/diamond/Diamond.spec.ts
@@ -77,7 +77,7 @@ describe('constructor', () => {
 
     const diamond = await createDiamond({
       additionalInits: [
-        buildAccessControlAddAdminsInitFunction(accessControlInit, [{ role: ROLE1, admins: [PLAYER1.address] }]),
+        buildAccessControlAddAdminsInitFunction(accessControlInit, [{ role: ROLE1, members: [PLAYER1.address] }]),
       ],
     });
 

--- a/spec/contracts/facets/diamond/Diamond-diamondCut.spec.ts
+++ b/spec/contracts/facets/diamond/Diamond-diamondCut.spec.ts
@@ -59,7 +59,7 @@ describe('add', () => {
 
     await asDiamondCut(diamond).diamondCut(
       [buildDiamondFacetCut(loupeFacet)],
-      buildAccessControlAddAdminsInitFunction(accessControlInit, [{ role: ROLE1, admins: [PLAYER1.address] }]),
+      buildAccessControlAddAdminsInitFunction(accessControlInit, [{ role: ROLE1, members: [PLAYER1.address] }]),
     );
 
     const accessControl = IAccessControl__factory.connect(diamond.address, INITIALIZER);
@@ -150,7 +150,7 @@ describe('replace', () => {
 
     await asDiamondCut(diamond).diamondCut(
       [buildDiamondFacetCut(loupeFacet2, DiamondFacetCutAction.Replace)],
-      buildAccessControlAddAdminsInitFunction(accessControlInit, [{ role: ROLE1, admins: [PLAYER1.address] }]),
+      buildAccessControlAddAdminsInitFunction(accessControlInit, [{ role: ROLE1, members: [PLAYER1.address] }]),
     );
 
     const accessControl = IAccessControl__factory.connect(diamond.address, INITIALIZER);
@@ -285,7 +285,7 @@ describe('remove', () => {
 
     await asDiamondCut(diamond).diamondCut(
       [buildDiamondFacetCut(loupeFacet, DiamondFacetCutAction.Remove)],
-      buildAccessControlAddAdminsInitFunction(accessControlInit, [{ role: ROLE1, admins: [PLAYER1.address] }]),
+      buildAccessControlAddAdminsInitFunction(accessControlInit, [{ role: ROLE1, members: [PLAYER1.address] }]),
     );
 
     const accessControl = IAccessControl__factory.connect(diamond.address, INITIALIZER);

--- a/spec/contracts/facets/diamond/DiamondInit.spec.ts
+++ b/spec/contracts/facets/diamond/DiamondInit.spec.ts
@@ -35,10 +35,10 @@ describe('initializeDiamond', () => {
     const diamond = await createDiamond();
 
     const init1 = buildAccessControlAddAdminsInitFunction(accessControlInit, [
-      { role: ROLE1, admins: [PLAYER1.address] },
+      { role: ROLE1, members: [PLAYER1.address] },
     ]);
     const init2 = buildAccessControlAddAdminsInitFunction(accessControlInit, [
-      { role: ROLE2, admins: [PLAYER2.address] },
+      { role: ROLE2, members: [PLAYER2.address] },
     ]);
 
     await asDiamondCut(diamond).diamondCut(

--- a/spec/contracts/facets/transfer/TransferFacet.spec.ts
+++ b/spec/contracts/facets/transfer/TransferFacet.spec.ts
@@ -46,9 +46,9 @@ const createTransferring = async () =>
   asTransferring(
     await createDiamond({
       additionalCuts: [buildDiamondFacetCut(await deployTransferFacet())],
-      additionalRoleAdmins: [
-        { role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] },
-        { role: TRANSFER_AGENT_ROLE, admins: [TRANSFER_AGENT.address] },
+      additionalRoleMembers: [
+        { role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] },
+        { role: TRANSFER_AGENT_ROLE, members: [TRANSFER_AGENT.address] },
       ],
     }),
   );
@@ -60,10 +60,10 @@ const createDisableableTransferring = async () =>
         buildDiamondFacetCut(await deployTransferFacet()),
         buildDiamondFacetCut(await deployDisableableFacet()),
       ],
-      additionalRoleAdmins: [
-        { role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] },
-        { role: DISABLER_ROLE, admins: [DISABLER.address] },
-        { role: TRANSFER_AGENT_ROLE, admins: [TRANSFER_AGENT.address] },
+      additionalRoleMembers: [
+        { role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] },
+        { role: DISABLER_ROLE, members: [DISABLER.address] },
+        { role: TRANSFER_AGENT_ROLE, members: [TRANSFER_AGENT.address] },
       ],
     }),
   );

--- a/spec/helpers/DiamondHelper.ts
+++ b/spec/helpers/DiamondHelper.ts
@@ -18,7 +18,7 @@
  */
 
 import { Interface } from 'ethers/lib/utils';
-import { AccessRoleAdmins } from '../../src/contracts/access';
+import { AccessRoleMembers } from '../../src/contracts/access';
 import { ZERO_ADDRESS } from '../../src/contracts/accounts';
 import {
   buildDiamondFacetCut,
@@ -156,7 +156,7 @@ export const combineDiamondInitFunctions = async (
 
 export interface ExtensibleDiamondOptions {
   additionalCuts?: DiamondFacetCut[];
-  additionalRoleAdmins?: AccessRoleAdmins[];
+  additionalRoleMembers?: AccessRoleMembers[];
   additionalInits?: DiamondInitFunction[];
 }
 
@@ -165,9 +165,9 @@ export const combineExtensibleDiamondOptions = (
   additionalOptions: ExtensibleDiamondOptions,
 ): ExtensibleDiamondOptions => ({
   additionalCuts: [...(baseOptions.additionalCuts || []), ...(additionalOptions.additionalCuts || [])],
-  additionalRoleAdmins: [
-    ...(baseOptions.additionalRoleAdmins || []),
-    ...(additionalOptions.additionalRoleAdmins || []),
+  additionalRoleMembers: [
+    ...(baseOptions.additionalRoleMembers || []),
+    ...(additionalOptions.additionalRoleMembers || []),
   ],
   additionalInits: [...(baseOptions.additionalInits || []), ...(additionalOptions.additionalInits || [])],
 });

--- a/spec/helpers/facets/AccessControlFacetHelper.ts
+++ b/spec/helpers/facets/AccessControlFacetHelper.ts
@@ -20,7 +20,7 @@
 import { Contract, Signer } from 'ethers';
 import {
   AccessRole,
-  AccessRoleAdmins,
+  AccessRoleMembers,
   buildAccessControlAddAdminsInitFunction,
   buildAccessControlInitAdminsInitFunction,
   buildDelegatingAccessControlAddDelegateInitFunction,
@@ -75,7 +75,7 @@ export type AccessControlInitOptions = {
       additionalRoles?: AccessRole[];
     }
   | {
-      additionalRoleAdmins?: AccessRoleAdmins[];
+      additionalRoleMembers?: AccessRoleMembers[];
     }
 );
 
@@ -97,8 +97,8 @@ export const buildAccessControlInitFunction = async (
   options: AccessControlInitOptions,
 ): Promise<DiamondInitFunction> => {
   const accessControlInit = options.accessControlInit || (await deployAccessControlInit());
-  if ('additionalRoleAdmins' in options && options.additionalRoleAdmins) {
-    return buildAccessControlAddAdminsInitFunction(accessControlInit, options.additionalRoleAdmins);
+  if ('additionalRoleMembers' in options && options.additionalRoleMembers) {
+    return buildAccessControlAddAdminsInitFunction(accessControlInit, options.additionalRoleMembers);
   }
 
   const initRoles = [SUPER_ADMIN_ROLE, ...(('additionalRoles' in options && options.additionalRoles) || [])];

--- a/spec/helpers/facets/ActivityExecutorHelper.ts
+++ b/spec/helpers/facets/ActivityExecutorHelper.ts
@@ -41,9 +41,9 @@ export const createActivityExecutor = async (options: CreateActivityExecutorOpti
       combineExtensibleDiamondOptions(
         {
           additionalCuts: [buildDiamondFacetCut(await deployActivityExecutorFacet())],
-          additionalRoleAdmins: [
-            { role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] },
-            { role: ADMIN_ROLE, admins: [PLAYER_ADMIN.address] },
+          additionalRoleMembers: [
+            { role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] },
+            { role: ADMIN_ROLE, members: [PLAYER_ADMIN.address] },
           ],
         },
         options,

--- a/spec/helpers/facets/ActivityFacetHelper.ts
+++ b/spec/helpers/facets/ActivityFacetHelper.ts
@@ -35,7 +35,7 @@ export const createActivity = async (options: CreateActivityOptions = {}) =>
       combineExtensibleDiamondOptions(
         {
           additionalCuts: [buildDiamondFacetCut(await deployActivityFacet())],
-          additionalRoleAdmins: [{ role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] }],
+          additionalRoleMembers: [{ role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] }],
         },
         options,
       ),

--- a/spec/helpers/facets/ArtifactFacetHelper.ts
+++ b/spec/helpers/facets/ArtifactFacetHelper.ts
@@ -48,7 +48,7 @@ export const createArtifact = async (initialUses: number = 1, options: CreateArt
       combineExtensibleDiamondOptions(
         {
           additionalCuts: [buildDiamondFacetCut(await deployArtifactFacet())],
-          additionalRoleAdmins: [{ role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] }],
+          additionalRoleMembers: [{ role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] }],
           additionalInits: [
             buildArtifactInitFunction(await deployArtifactInit(), {
               initialUses,
@@ -69,7 +69,7 @@ export const createMintableArtifact = async (initialUses: number = 1, options: E
       combineExtensibleDiamondOptions(
         {
           additionalCuts: [buildDiamondFacetCut(await deployArtifactMintFacet())],
-          additionalRoleAdmins: [{ role: MINTER_ROLE, admins: [ARTIFACT_MINTER.address] }],
+          additionalRoleMembers: [{ role: MINTER_ROLE, members: [ARTIFACT_MINTER.address] }],
         },
         options,
       ),

--- a/spec/helpers/facets/ConsumableConsumerFacetHelper.ts
+++ b/spec/helpers/facets/ConsumableConsumerFacetHelper.ts
@@ -62,7 +62,7 @@ export const buildConsumableConsumerDiamondAdditions = async function (
   return combineExtensibleDiamondOptions(
     {
       additionalCuts: [buildDiamondFacetCut(consumerFacet)],
-      additionalRoleAdmins: [{ role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] }],
+      additionalRoleMembers: [{ role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] }],
       additionalInits: [buildSetRequiredConsumablesFunction(consumerInit, requiredConsumables)],
     },
     options,

--- a/spec/helpers/facets/ConsumableExchangingFacetHelper.ts
+++ b/spec/helpers/facets/ConsumableExchangingFacetHelper.ts
@@ -63,7 +63,7 @@ export const buildConsumableExchangingDiamondAdditions = async function (
         buildDiamondFacetCut(await deployConsumableConsumerFacet()),
         buildDiamondFacetCut(await deployConsumableProviderFacet()),
       ],
-      additionalRoleAdmins: [{ role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] }],
+      additionalRoleMembers: [{ role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] }],
       additionalInits: [
         buildConsumableExchangingInitFunction(await deployConsumableExchangingInit(), {
           exchange,

--- a/spec/helpers/facets/ConsumableFacetHelper.ts
+++ b/spec/helpers/facets/ConsumableFacetHelper.ts
@@ -18,7 +18,7 @@
  */
 
 import { Contract, Signer } from 'ethers';
-import { AccessRoleAdmins } from '../../../src/contracts/access';
+import { AccessRoleMembers } from '../../../src/contracts/access';
 import { ConsumableAmount, ConsumableAmountBN } from '../../../src/contracts/consumables';
 import { buildDiamondFacetCut, DiamondFacetCut } from '../../../src/contracts/diamonds';
 import { MINTER_ROLE, SUPER_ADMIN_ROLE } from '../../../src/contracts/roles';
@@ -49,9 +49,9 @@ export const createConsumable = async (options: CreateConsumableOptions = {}) =>
             buildDiamondFacetCut(await deployConsumableFacet()),
             buildDiamondFacetCut(await deployConsumableMintFacet()),
           ],
-          additionalRoleAdmins: [
-            { role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] },
-            { role: MINTER_ROLE, admins: [CONSUMABLE_MINTER.address] },
+          additionalRoleMembers: [
+            { role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] },
+            { role: MINTER_ROLE, members: [CONSUMABLE_MINTER.address] },
           ],
         },
         options,
@@ -63,14 +63,14 @@ export const createDisableableConsumable = async () => await createConsumable(aw
 
 export const combineConsumableAdditions = (...additions: ExtensibleDiamondOptions[]): ExtensibleDiamondOptions => {
   const additionalCuts: DiamondFacetCut[] = [];
-  const additionalRoleAdmins: AccessRoleAdmins[] = [];
+  const additionalRoleMembers: AccessRoleMembers[] = [];
 
   additions.forEach((addition) => {
     addition.additionalCuts?.forEach((cut) => additionalCuts.push(cut));
-    addition.additionalRoleAdmins?.forEach((admins) => additionalRoleAdmins.push(admins));
+    addition.additionalRoleMembers?.forEach((admins) => additionalRoleMembers.push(admins));
   });
 
-  return { additionalCuts, additionalRoleAdmins };
+  return { additionalCuts, additionalRoleMembers: additionalRoleMembers };
 };
 
 export const deployConsumableFacet = () => new ConsumableFacet__factory(INITIALIZER).deploy();

--- a/spec/helpers/facets/ConsumableLimitFacetHelper.ts
+++ b/spec/helpers/facets/ConsumableLimitFacetHelper.ts
@@ -17,7 +17,7 @@
  * along with Paypr Ethereum Contracts.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Contract, Signer } from 'ethers';
-import { AccessRoleAdmins } from '../../../src/contracts/access';
+import { AccessRoleMembers } from '../../../src/contracts/access';
 import { ConsumableHooksLike } from '../../../src/contracts/consumables';
 import { buildConsumableLimitInitFunction } from '../../../src/contracts/consumables/limit';
 import { buildDiamondFacetCut, DiamondFacetCut, DiamondInitFunction } from '../../../src/contracts/diamonds';
@@ -47,7 +47,7 @@ export interface CreateLimitConsumableOptions {
   limitInit?: ConsumableLimitInit;
   limitConsumableHooks?: ConsumableHooksLike;
   additionalCuts?: DiamondFacetCut[];
-  additionalRoleAdmins?: AccessRoleAdmins[];
+  additionalRoleMembers?: AccessRoleMembers[];
   additionalInits?: DiamondInitFunction[];
 }
 
@@ -71,7 +71,7 @@ export const createLimitedConsumable = async (options: CreateLimitConsumableOpti
 
 export const buildLimiterConsumableAdditions = async (): Promise<ExtensibleDiamondOptions> => ({
   additionalCuts: [buildDiamondFacetCut(await deployConsumableLimiterFacet())],
-  additionalRoleAdmins: [{ role: LIMITER_ROLE, admins: [CONSUMABLE_LIMITER.address] }],
+  additionalRoleMembers: [{ role: LIMITER_ROLE, members: [CONSUMABLE_LIMITER.address] }],
 });
 
 export const deployConsumableLimitFacet = () => new ConsumableLimitFacet__factory(INITIALIZER).deploy();

--- a/spec/helpers/facets/ConsumableProviderFacetHelper.ts
+++ b/spec/helpers/facets/ConsumableProviderFacetHelper.ts
@@ -62,7 +62,7 @@ export const buildConsumableProviderDiamondAdditions = async (
   return combineExtensibleDiamondOptions(
     {
       additionalCuts: [buildDiamondFacetCut(providerFacet)],
-      additionalRoleAdmins: [{ role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] }],
+      additionalRoleMembers: [{ role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] }],
       additionalInits: [buildSetProvidedConsumablesFunction(providerInit, requiredConsumables)],
     },
     options,

--- a/spec/helpers/facets/ContractInfoFacetHelper.ts
+++ b/spec/helpers/facets/ContractInfoFacetHelper.ts
@@ -18,7 +18,7 @@
  */
 
 import { Contract } from 'ethers';
-import { AccessRoleAdmins } from '../../../src/contracts/access';
+import { AccessRoleMembers } from '../../../src/contracts/access';
 import { buildContractInfoInitializeInitFunction, ContractInfoInitOptions } from '../../../src/contracts/contractInfo';
 import { buildDiamondFacetCut, DiamondFacetCut, DiamondInitFunction } from '../../../src/contracts/diamonds';
 import { SUPER_ADMIN_ROLE } from '../../../src/contracts/roles';
@@ -34,7 +34,7 @@ export const asContractInfo = (contract: Contract) => IContractInfo__factory.con
 
 export interface ContractInfoCreateOptions extends ContractInfoInitOptions {
   additionalCuts?: DiamondFacetCut[];
-  additionalRoleAdmins?: AccessRoleAdmins[];
+  additionalRoleMembers?: AccessRoleMembers[];
   additionalInits?: DiamondInitFunction[];
 }
 
@@ -46,9 +46,9 @@ export const createContractInfo = async (options: ContractInfoCreateOptions = {}
         buildContractInfoInitializeInitFunction(await deployContractInfoInit(), options),
         ...(options.additionalInits || []),
       ],
-      additionalRoleAdmins: [
-        { role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] },
-        ...(options.additionalRoleAdmins || []),
+      additionalRoleMembers: [
+        { role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] },
+        ...(options.additionalRoleMembers || []),
       ],
     }),
   );

--- a/spec/helpers/facets/DisableableFacetHelper.ts
+++ b/spec/helpers/facets/DisableableFacetHelper.ts
@@ -33,9 +33,9 @@ export const createDisableable = async (additionalCuts: DiamondFacetCut[] = []) 
   asDisableable(
     await createDiamond({
       additionalCuts: [buildDiamondFacetCut(await deployDisableableFacet()), ...additionalCuts],
-      additionalRoleAdmins: [
-        { role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] },
-        { role: DISABLER_ROLE, admins: [DISABLER.address] },
+      additionalRoleMembers: [
+        { role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] },
+        { role: DISABLER_ROLE, members: [DISABLER.address] },
       ],
     }),
   );
@@ -45,5 +45,5 @@ export const deployTestEnabled = () => new TestEnabled__factory(INITIALIZER).dep
 
 export const buildDisableableDiamondAdditions = async (): Promise<ExtensibleDiamondOptions> => ({
   additionalCuts: [buildDiamondFacetCut(await deployDisableableFacet())],
-  additionalRoleAdmins: [{ role: DISABLER_ROLE, admins: [DISABLER.address] }],
+  additionalRoleMembers: [{ role: DISABLER_ROLE, members: [DISABLER.address] }],
 });

--- a/spec/helpers/facets/ERC721FacetHelper.ts
+++ b/spec/helpers/facets/ERC721FacetHelper.ts
@@ -55,7 +55,7 @@ export const createERC721 = async (options: CreateERC721Options = {}) =>
       combineExtensibleDiamondOptions(
         {
           additionalCuts: [buildDiamondFacetCut(await deployERC721Facet())],
-          additionalRoleAdmins: [{ role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] }],
+          additionalRoleMembers: [{ role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] }],
         },
         options,
       ),
@@ -68,7 +68,7 @@ export const createMintableERC721 = async (options: ExtensibleDiamondOptions = {
       combineExtensibleDiamondOptions(
         {
           additionalCuts: [buildDiamondFacetCut(await deployERC721MintFacet())],
-          additionalRoleAdmins: [{ role: MINTER_ROLE, admins: [ARTIFACT_MINTER.address] }],
+          additionalRoleMembers: [{ role: MINTER_ROLE, members: [ARTIFACT_MINTER.address] }],
         },
         options,
       ),

--- a/spec/helpers/facets/SkillAcquirerHelper.ts
+++ b/spec/helpers/facets/SkillAcquirerHelper.ts
@@ -35,9 +35,9 @@ export const createSkillAcquirer = async (options: CreateSkillAcquirerOptions = 
       combineExtensibleDiamondOptions(
         {
           additionalCuts: [buildDiamondFacetCut(await deploySkillAcquirerFacet())],
-          additionalRoleAdmins: [
-            { role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] },
-            { role: ADMIN_ROLE, admins: [PLAYER_ADMIN.address] },
+          additionalRoleMembers: [
+            { role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] },
+            { role: ADMIN_ROLE, members: [PLAYER_ADMIN.address] },
           ],
         },
         options,

--- a/spec/helpers/facets/SkillConstrainedFacetHelper.ts
+++ b/spec/helpers/facets/SkillConstrainedFacetHelper.ts
@@ -56,7 +56,7 @@ export const createSkillConstrained = async (
       combineExtensibleDiamondOptions(
         {
           additionalCuts: [buildDiamondFacetCut(skillConstrainedFacet)],
-          additionalRoleAdmins: [{ role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] }],
+          additionalRoleMembers: [{ role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] }],
           additionalInits: [buildSetRequiredSkillsFunction(skillConstrainedInit, requiredSkills)],
         },
         options,

--- a/spec/helpers/facets/SkillFacetHelper.ts
+++ b/spec/helpers/facets/SkillFacetHelper.ts
@@ -48,7 +48,7 @@ export const createSkill = async (options: CreateSkillOptions = {}) =>
       combineExtensibleDiamondOptions(
         {
           additionalCuts: [buildDiamondFacetCut(await deploySkillFacet())],
-          additionalRoleAdmins: [{ role: SUPER_ADMIN_ROLE, admins: [INITIALIZER.address] }],
+          additionalRoleMembers: [{ role: SUPER_ADMIN_ROLE, members: [INITIALIZER.address] }],
         },
         options,
       ),

--- a/spec/helpers/facets/TransferFacetHelper.ts
+++ b/spec/helpers/facets/TransferFacetHelper.ts
@@ -10,7 +10,7 @@ export const asTransferring = (contract: Contract, signer: Signer = TRANSFER_AGE
 
 export const buildTransferringDiamondAdditions = async (): Promise<ExtensibleDiamondOptions> => ({
   additionalCuts: [buildDiamondFacetCut(await deployTransferFacet())],
-  additionalRoleAdmins: [{ role: TRANSFER_AGENT_ROLE, admins: [TRANSFER_AGENT.address] }],
+  additionalRoleMembers: [{ role: TRANSFER_AGENT_ROLE, members: [TRANSFER_AGENT.address] }],
 });
 
 export const deployTransferFacet = () => new TransferFacet__factory(INITIALIZER).deploy();

--- a/src/contracts/access.ts
+++ b/src/contracts/access.ts
@@ -26,9 +26,9 @@ export type AccessRole = string;
 
 export const DEFAULT_ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
-export interface AccessRoleAdmins {
+export interface AccessRoleMembers {
   role: AccessRole;
-  admins: AccountAddress[];
+  members: AccountAddress[];
 }
 
 export const buildAccessControlInitAdminsInitFunction = (
@@ -40,11 +40,11 @@ export const buildAccessControlInitAdminsInitFunction = (
 });
 
 export const encodeAccessControlInitAdminsCallData = (accessControlInit: AccessControlInit, roles: AccessRole[]) =>
-  accessControlInit.interface.encodeFunctionData('initializeAdmins', [roles]);
+  accessControlInit.interface.encodeFunctionData('addRoles', [roles]);
 
 export const buildAccessControlAddAdminsInitFunction = (
   accessControlInit: AccessControlInit,
-  roleAdmins: AccessRoleAdmins[],
+  roleAdmins: AccessRoleMembers[],
 ): DiamondInitFunction => ({
   initAddress: accessControlInit.address,
   callData: encodeAccessControlAddAdminsCallData(accessControlInit, roleAdmins),
@@ -52,8 +52,8 @@ export const buildAccessControlAddAdminsInitFunction = (
 
 export const encodeAccessControlAddAdminsCallData = (
   accessControlInit: AccessControlInit,
-  roleAdmins: AccessRoleAdmins[],
-) => accessControlInit.interface.encodeFunctionData('addAdmins', [roleAdmins]);
+  roleAdmins: AccessRoleMembers[],
+) => accessControlInit.interface.encodeFunctionData('addMembers', [roleAdmins]);
 
 export const buildDelegatingAccessControlAddDelegateInitFunction = (
   delegatingAccessControlInit: DelegatingAccessControlInit,


### PR DESCRIPTION
The name of the functions, fields and structures were misleading.